### PR TITLE
Fix modals with progress-indicators not resizing on load

### DIFF
--- a/src/app/public/modules/progress-indicator/fixtures/progress-indicator.component.fixture.ts
+++ b/src/app/public/modules/progress-indicator/fixtures/progress-indicator.component.fixture.ts
@@ -44,6 +44,7 @@ export class ProgressIndicatorTestComponent {
 
   public activeIndex = 0;
   public resetWasClicked = false;
+  public progressChangesEmitted = false;
 
   @ViewChild(SkyProgressIndicatorComponent)
   public progressIndicator: SkyProgressIndicatorComponent;
@@ -73,6 +74,7 @@ export class ProgressIndicatorTestComponent {
   }
 
   public updateIndex(changes: SkyProgressIndicatorChange): void {
+    this.progressChangesEmitted = true;
     this.activeIndex = changes.activeIndex;
     this.changeDetector.detectChanges();
   }

--- a/src/app/public/modules/progress-indicator/progress-indicator.component.spec.ts
+++ b/src/app/public/modules/progress-indicator/progress-indicator.component.spec.ts
@@ -30,6 +30,7 @@ import {
 import {
   SkyProgressIndicatorDisplayMode
 } from './types/progress-indicator-mode';
+import { SkyWindowRefService } from '@skyux/core';
 
 describe('Progress indicator component', function () {
 
@@ -45,6 +46,7 @@ describe('Progress indicator component', function () {
         ProgressIndicatorTestComponent
       ],
       providers: [
+        SkyWindowRefService,
         {
           provide: SkyLibResourcesService,
           useClass: SkyLibResourcesTestService

--- a/src/app/public/modules/progress-indicator/progress-indicator.component.spec.ts
+++ b/src/app/public/modules/progress-indicator/progress-indicator.component.spec.ts
@@ -55,6 +55,13 @@ describe('Progress indicator component', function () {
     fixture = TestBed.createComponent(ProgressIndicatorTestComponent);
   });
 
+  it('should not run the progressChanges emitter until a tick has occurred.', fakeAsync(() => {
+    fixture.detectChanges();
+    expect(fixture.componentInstance.progressChangesEmitted).toBeFalsy();
+    tick();
+    expect(fixture.componentInstance.progressChangesEmitted).toBeTruthy();
+  }));
+
   it('should use horizontal display if set', fakeAsync(() => {
     fixture.componentInstance.displayMode = SkyProgressIndicatorDisplayMode.Horizontal;
     fixture.detectChanges();

--- a/src/app/public/modules/progress-indicator/progress-indicator.component.spec.ts
+++ b/src/app/public/modules/progress-indicator/progress-indicator.component.spec.ts
@@ -19,6 +19,10 @@ import {
 } from '@skyux-sdk/testing';
 
 import {
+  SkyWindowRefService
+} from '@skyux/core';
+
+import {
   SkyProgressIndicatorModule,
   SkyProgressIndicatorMessageType
 } from '.';
@@ -30,7 +34,6 @@ import {
 import {
   SkyProgressIndicatorDisplayMode
 } from './types/progress-indicator-mode';
-import { SkyWindowRefService } from '@skyux/core';
 
 describe('Progress indicator component', function () {
 

--- a/src/app/public/modules/progress-indicator/progress-indicator.component.ts
+++ b/src/app/public/modules/progress-indicator/progress-indicator.component.ts
@@ -5,9 +5,9 @@ import {
   EventEmitter,
   Input,
   OnDestroy,
+  Optional,
   Output,
-  QueryList,
-  Optional
+  QueryList
 } from '@angular/core';
 
 import {
@@ -15,16 +15,21 @@ import {
 } from 'rxjs/Subject';
 
 import {
+  SkyWindowRefService
+} from '@skyux/core';
+
+import {
   SkyProgressIndicatorChange,
   SkyProgressIndicatorMessageType
 } from './types';
+
 import {
   SkyProgressIndicatorItemComponent
 } from './progress-indicator-item';
+
 import {
   SkyProgressIndicatorDisplayMode
 } from './types/progress-indicator-mode';
-import { SkyWindowRefService } from '@skyux/core';
 
 @Component({
   selector: 'sky-progress-indicator',
@@ -72,7 +77,7 @@ export class SkyProgressIndicatorComponent implements AfterContentInit, OnDestro
   private ngUnsubscribe = new Subject();
 
   constructor(
-    @Optional() private windowSvc: SkyWindowRefService
+    @Optional() private windowService: SkyWindowRefService
   ) {}
 
   public ngAfterContentInit(): void {
@@ -121,8 +126,9 @@ export class SkyProgressIndicatorComponent implements AfterContentInit, OnDestro
       }
     }
 
-    // setTimeout required to ensure listeners aren't triggered until the view lifecycle has completed. Issue: blackbaud/skyux2#2221
-    this.windowSvc.getWindow().setTimeout(() => {
+    // A timeout is needed to ensure that subscriptions are executed after all Angular lifecycle hooks have completed.
+    // For example, if a subscriber executed `detectChanges`, it would short-circuit any remaining lifecycle hooks.
+    this.windowService.getWindow().setTimeout(() => {
       this.progressChanges.emit({
         activeIndex: this.activeIndex
       });

--- a/src/app/public/modules/progress-indicator/progress-indicator.component.ts
+++ b/src/app/public/modules/progress-indicator/progress-indicator.component.ts
@@ -114,8 +114,10 @@ export class SkyProgressIndicatorComponent implements AfterContentInit, OnDestro
         firstItem.isActive = true;
       }
     }
-    this.progressChanges.emit({
-      activeIndex: this.activeIndex
+    setTimeout(() => {
+      this.progressChanges.emit({
+        activeIndex: this.activeIndex
+      });
     });
 
     // Set the last item

--- a/src/app/public/modules/progress-indicator/progress-indicator.component.ts
+++ b/src/app/public/modules/progress-indicator/progress-indicator.component.ts
@@ -23,6 +23,7 @@ import {
 import {
   SkyProgressIndicatorDisplayMode
 } from './types/progress-indicator-mode';
+import { SkyWindowRefService } from '@skyux/core';
 
 @Component({
   selector: 'sky-progress-indicator',
@@ -68,6 +69,10 @@ export class SkyProgressIndicatorComponent implements AfterContentInit, OnDestro
   private _displayMode: SkyProgressIndicatorDisplayMode;
   private _isPassive: boolean;
   private ngUnsubscribe = new Subject();
+
+  constructor(
+    private windowSvc: SkyWindowRefService
+  ) {}
 
   public ngAfterContentInit(): void {
     // Set up observation of progress command messages
@@ -116,7 +121,7 @@ export class SkyProgressIndicatorComponent implements AfterContentInit, OnDestro
     }
 
     // setTimeout required to ensure listeners aren't triggered until the view lifecycle has completed. Issue: blackbaud/skyux2#2221
-    setTimeout(() => {
+    this.windowSvc.getWindow().setTimeout(() => {
       this.progressChanges.emit({
         activeIndex: this.activeIndex
       });

--- a/src/app/public/modules/progress-indicator/progress-indicator.component.ts
+++ b/src/app/public/modules/progress-indicator/progress-indicator.component.ts
@@ -114,9 +114,8 @@ export class SkyProgressIndicatorComponent implements AfterContentInit, OnDestro
         firstItem.isActive = true;
       }
     }
-    
-    // setTimeout required to allow other ngAfterViewContentInit's of
-    // parent components to execute before this event triggers. Issue: blackbaud/skyux2#2221
+
+    // setTimeout required to ensure listeners aren't triggered until the view lifecycle has completed. Issue: blackbaud/skyux2#2221
     setTimeout(() => {
       this.progressChanges.emit({
         activeIndex: this.activeIndex

--- a/src/app/public/modules/progress-indicator/progress-indicator.component.ts
+++ b/src/app/public/modules/progress-indicator/progress-indicator.component.ts
@@ -114,6 +114,9 @@ export class SkyProgressIndicatorComponent implements AfterContentInit, OnDestro
         firstItem.isActive = true;
       }
     }
+    
+    // setTimeout required to allow other ngAfterViewContentInit's of
+    // parent components to execute before this event triggers. Issue: blackbaud/skyux2#2221
     setTimeout(() => {
       this.progressChanges.emit({
         activeIndex: this.activeIndex

--- a/src/app/public/modules/progress-indicator/progress-indicator.component.ts
+++ b/src/app/public/modules/progress-indicator/progress-indicator.component.ts
@@ -6,7 +6,8 @@ import {
   Input,
   OnDestroy,
   Output,
-  QueryList
+  QueryList,
+  Optional
 } from '@angular/core';
 
 import {
@@ -71,7 +72,7 @@ export class SkyProgressIndicatorComponent implements AfterContentInit, OnDestro
   private ngUnsubscribe = new Subject();
 
   constructor(
-    private windowSvc: SkyWindowRefService
+    @Optional() private windowSvc: SkyWindowRefService
   ) {}
 
   public ngAfterContentInit(): void {


### PR DESCRIPTION
Emitting the progressChanges event to the parent of the modal triggers its subscription and seems to skip the ngAfterViewInit of the modal inside it.
```
<sky-modal>
  <sky-modal-content>
    <sky-progress-indicator (progressChanges)="doStuff($event)">
    </sky-progress-indicator>
  </sky-modal-content>
</sky-modal>
```

Putting the emitter in a setTimeout delays the execution enough to let the remaining AfterViewInit's to execute before listeners to the progressChanges event are triggered.

Issue: blackbaud/skyux2#2221
Docs: N/A